### PR TITLE
feat: support multiple spore transfers in single transaction

### DIFF
--- a/src/routes/rgbpp/transaction.ts
+++ b/src/routes/rgbpp/transaction.ts
@@ -12,7 +12,8 @@ const transactionRoute: FastifyPluginCallback<Record<never, never>, Server, ZodT
     '/ckb-tx',
     {
       schema: {
-        description: 'Submit a RGB++ CKB transaction',
+        description:
+          'Submit a RGB++ CKB transaction. Note: When including multiple assets, especially Spore, in a single transaction, please evaluate and ensure the final CKB transaction size does not exceed 512,000 bytes, otherwise the CKB node will reject it and permanently prevent RGB++ assets from being unlocked.',
         tags: ['RGB++'],
         body: z.object({
           btc_txid: z.string(),

--- a/src/services/transaction.ts
+++ b/src/services/transaction.ts
@@ -317,17 +317,23 @@ export default class TransactionProcessor
     const inputs = await Promise.all(
       signedTx.inputs.map((input) => this.limit(() => this.cradle.ckb.rpc.getLiveCell(input.previousOutput!, true))),
     );
+
+    // Find spore input cells
     const sporeLiveCells = inputs
       .filter(({ status, cell }) => {
         return status === 'live' && cell?.output.type && isClusterSporeTypeSupported(cell?.output.type, IS_MAINNET);
       })
       .map((liveCell) => liveCell.cell!);
+
     if (sporeLiveCells.length > 0) {
-      signedTx.witnesses[signedTx.witnesses.length - 1] = generateSporeTransferCoBuild(
-        sporeLiveCells,
-        signedTx.outputs,
-      );
+      // Find all spore outputs
+      const sporeOutputs = signedTx.outputs.filter((output) => {
+        return output.type && isClusterSporeTypeSupported(output.type, IS_MAINNET);
+      });
+
+      signedTx.witnesses[signedTx.witnesses.length - 1] = generateSporeTransferCoBuild(sporeLiveCells, sporeOutputs);
     }
+
     return signedTx;
   }
 

--- a/src/services/transaction.ts
+++ b/src/services/transaction.ts
@@ -1,5 +1,6 @@
 import { bytes } from '@ckb-lumos/codec';
 import { remove0x, transactionToHex } from '@rgbpp-sdk/btc';
+import pLimit from 'p-limit';
 import {
   RGBPPLock,
   RGBPP_TX_ID_PLACEHOLDER,
@@ -96,6 +97,7 @@ export default class TransactionProcessor
 {
   private cradle: Cradle;
   private isRetryMissingTransactionsRunning = false;
+  private limit: pLimit.Limit;
 
   constructor(cradle: Cradle) {
     const defaultJobOptions = TransactionProcessor.getDefaultJobOptions(cradle.env);
@@ -110,6 +112,7 @@ export default class TransactionProcessor
       },
     });
     this.cradle = cradle;
+    this.limit = pLimit(20); // Control concurrency to avoid overwhelming CKB RPC
   }
 
   public static getDefaultJobOptions(env: Env) {
@@ -307,14 +310,12 @@ export default class TransactionProcessor
 
   /**
    * Append the spore cobuild witness to the transaction if the input contains spore cell
-   * (support spore transfer only for now, will support more in the future)
+   * (supports multiple spore transfers in a single transaction)
    * @param signedTx - the signed CKB transaction
    */
   private async appendSporeCobuildWitness(signedTx: CKBRawTransaction) {
     const inputs = await Promise.all(
-      signedTx.inputs.map(async (input) => {
-        return this.cradle.ckb.rpc.getLiveCell(input.previousOutput!, true);
-      }),
+      signedTx.inputs.map((input) => this.limit(() => this.cradle.ckb.rpc.getLiveCell(input.previousOutput!, true))),
     );
     const sporeLiveCells = inputs
       .filter(({ status, cell }) => {
@@ -324,7 +325,7 @@ export default class TransactionProcessor
     if (sporeLiveCells.length > 0) {
       signedTx.witnesses[signedTx.witnesses.length - 1] = generateSporeTransferCoBuild(
         sporeLiveCells,
-        signedTx.outputs.slice(0, 1),
+        signedTx.outputs,
       );
     }
     return signedTx;


### PR DESCRIPTION
Transfer two Spores in one transaction:
- BTC tx: https://mempool.space/testnet/tx/be5864d57dfb26505505813fd54a7826d807441c94ab712eb2268bbe1851edf0
- CKB tx: https://testnet.explorer.nervos.org/transaction/0xf433ed83d7e6d32c7b7f13b1d1376d1e6292d774d32bd5f8a869d090d03f8dca


Transfer one Spore in one transaction:
- BTC tx: https://mempool.space/testnet/tx/a500dc7ef0e37f36a780996c61996dcbdbc8ce4ff14d51f7c1ef4f0efe383e9d
- CKB tx: https://testnet.explorer.nervos.org/transaction/0x6978f686cfe3fe44d911ff0d4d642e03739ecf7ff66c47fe65c52d2ee5f95cda







