### PR TITLE
Add UTXO spending status to RGBPP asset endpoint

### DIFF
--- a/src/routes/bitcoin/transaction.ts
+++ b/src/routes/bitcoin/transaction.ts
@@ -4,6 +4,7 @@ import { Transaction } from './types';
 import { CUSTOM_HEADERS } from '../../constants';
 import z from 'zod';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { TxOutspend } from '../../services/bitcoin/schema';
 
 const transactionRoutes: FastifyPluginCallback<Record<never, never>, Server, ZodTypeProvider> = (fastify, _, done) => {
   fastify.post(
@@ -78,6 +79,32 @@ const transactionRoutes: FastifyPluginCallback<Record<never, never>, Server, Zod
       return { hex };
     },
   );
+
+  fastify.get(
+    '/:txid/outspend/:vout',
+    {
+      schema: {
+        description: 'Get the spending status of a transaction output',
+        tags: ['Bitcoin'],
+        params: z.object({
+          txid: z.string().length(64, 'should be a 64-character hex string').describe('The Bitcoin transaction id'),
+          vout: z.string().min(1, 'cannot be empty').pipe(z.coerce.number().min(0, 'cannot be negative')),
+        }),
+        response: {
+          200: TxOutspend,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { txid, vout } = request.params;
+      const outspend = await fastify.bitcoin.getTxOutspend({ txid, vout });
+      if (outspend.spent || outspend.status?.confirmed) {
+        reply.header(CUSTOM_HEADERS.ResponseCacheable, 'true');
+      }
+      return outspend;
+    },
+  );
+
   done();
 };
 

--- a/src/routes/rgbpp/assets.ts
+++ b/src/routes/rgbpp/assets.ts
@@ -72,6 +72,7 @@ const assetsRoute: FastifyPluginCallback<Record<never, never>, Server, ZodTypePr
           200: z.array(
             Cell.merge(
               z.object({
+                utxoSpent: z.boolean(),
                 typeHash: z.string().optional(),
               }),
             ),
@@ -81,6 +82,7 @@ const assetsRoute: FastifyPluginCallback<Record<never, never>, Server, ZodTypePr
     },
     async (request) => {
       const { btc_txid, vout } = request.params;
+      const outspend = await fastify.bitcoin.getTxOutspend({ txid: btc_txid, vout });
       const utxo: UTXO = {
         txid: btc_txid,
         vout,
@@ -96,6 +98,7 @@ const assetsRoute: FastifyPluginCallback<Record<never, never>, Server, ZodTypePr
         const typeHash = cell.cellOutput.type ? computeScriptHash(cell.cellOutput.type) : undefined;
         return {
           ...cell,
+          utxoSpent: outspend.spent,
           typeHash,
         };
       });

--- a/src/services/bitcoin/electrs.ts
+++ b/src/services/bitcoin/electrs.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
 import { IBitcoinDataProvider } from './interface';
-import { Block, RecommendedFees, Transaction, UTXO } from './schema';
+import { Block, RecommendedFees, Transaction, UTXO, TxOutspend } from './schema';
 
 export class ElectrsClient implements IBitcoinDataProvider {
   private request: AxiosInstance;
@@ -94,6 +94,11 @@ export class ElectrsClient implements IBitcoinDataProvider {
 
   public async getBlocksTipHash() {
     const response = await this.request.get<string>('/blocks/tip/hash');
+    return response.data;
+  }
+
+  public async getTxOutspend({ txid, vout }: { txid: string; vout: number }) {
+    const response = await this.request.get<TxOutspend>(`/tx/${txid}/outspend/${vout}`);
     return response.data;
   }
 }

--- a/src/services/bitcoin/index.ts
+++ b/src/services/bitcoin/index.ts
@@ -245,4 +245,8 @@ export default class BitcoinClient implements IBitcoinClient {
   public async getBlocksTipHash() {
     return this.call('getBlocksTipHash');
   }
+
+  public async getTxOutspend({ txid, vout }: { txid: string; vout: number }) {
+    return this.call('getTxOutspend', { txid, vout });
+  }
 }

--- a/src/services/bitcoin/interface.ts
+++ b/src/services/bitcoin/interface.ts
@@ -1,4 +1,4 @@
-import { Block, RecommendedFees, Transaction, UTXO } from './schema';
+import { Block, RecommendedFees, Transaction, UTXO, TxOutspend } from './schema';
 
 export interface IBitcoinDataProvider {
   getBaseURL(): Promise<string>;
@@ -13,6 +13,7 @@ export interface IBitcoinDataProvider {
   getBlockHeader({ hash }: { hash: string }): Promise<string>;
   getBlockTxids({ hash }: { hash: string }): Promise<string[]>;
   getBlocksTipHash(): Promise<string>;
+  getTxOutspend({ txid, vout }: { txid: string; vout: number }): Promise<TxOutspend>;
 }
 
 export type IBitcoinBroadcastBackuper = Pick<IBitcoinDataProvider, 'getBaseURL' | 'postTx'>;

--- a/src/services/bitcoin/mempool.ts
+++ b/src/services/bitcoin/mempool.ts
@@ -1,7 +1,7 @@
 import { Cradle } from '../../container';
 import { IBitcoinDataProvider } from './interface';
 import mempoolJS from '@mempool/mempool.js';
-import { Block, RecommendedFees, Transaction, UTXO } from './schema';
+import { Block, RecommendedFees, Transaction, TxOutspend, UTXO } from './schema';
 import * as Sentry from '@sentry/node';
 import { FeesMempoolBlocks } from '@mempool/mempool.js/lib/interfaces/bitcoin/fees';
 
@@ -149,5 +149,10 @@ export class MempoolClient implements IBitcoinDataProvider {
   public async getBlocksTipHash() {
     const response = await this.mempool.bitcoin.blocks.getBlocksTipHash();
     return response;
+  }
+
+  public async getTxOutspend({ txid, vout }: { txid: string; vout: number }) {
+    const response = await this.mempool.bitcoin.transactions.getTxOutspend({ txid, vout });
+    return TxOutspend.parse(response);
   }
 }

--- a/src/services/bitcoin/schema.ts
+++ b/src/services/bitcoin/schema.ts
@@ -85,9 +85,17 @@ export const RecommendedFees = z.object({
   minimumFee: z.number(),
 });
 
+export const TxOutspend = z.object({
+  spent: z.boolean(),
+  txid: z.string().optional(),
+  vout: z.number().optional(),
+  status: Status.optional(),
+});
+
 export type ChainInfo = z.infer<typeof ChainInfo>;
 export type Block = z.infer<typeof Block>;
 export type Balance = z.infer<typeof Balance>;
 export type UTXO = z.infer<typeof UTXO>;
 export type Transaction = z.infer<typeof Transaction>;
 export type RecommendedFees = z.infer<typeof RecommendedFees>;
+export type TxOutspend = z.infer<typeof TxOutspend>;


### PR DESCRIPTION
- Added a new endpoint to check transaction output spending status.

- Enhanced `/rgbpp/v1/assets/{btc_txid}/{vout}` to include UTXO spending status in the response.